### PR TITLE
fix: do not send Authorization header if no token

### DIFF
--- a/src/app/interceptors/token.interceptor.ts
+++ b/src/app/interceptors/token.interceptor.ts
@@ -25,7 +25,9 @@ export class TokenInterceptor implements HttpInterceptor {
 
   intercept(req: HttpRequest<any>, next: HttpHandler): Observable<HttpEvent<any>> {
 
-    const dupReq = req.clone({ headers: req.headers.set('Authorization', `Bearer ${this.authService.getToken()}`) });
+    const token = this.authService.getToken();
+
+    const dupReq = token ? req.clone({ headers: req.headers.set('Authorization', `Bearer ${token }`) }) : req;
     return next.handle(dupReq);
   }
 }


### PR DESCRIPTION
Do not send Authorization header with `Bearer null` when no token