### PR TITLE
feat: Add 'Passwordless' tab to allow user in-app Webauthn registration

### DIFF
--- a/src/app/account/account.component.html
+++ b/src/app/account/account.component.html
@@ -146,5 +146,44 @@
         <mat-divider></mat-divider>
       </div>
     </mat-tab>
+    <mat-tab label="Passwordless">
+      <h3>Credentials</h3>
+      <mat-divider></mat-divider>
+      <div style="padding: 10px;">
+        <button mat-raised-button class="mat-primary" (click)="registerCredential()" >Register</button>
+      </div>
+      <div style="padding: 10px;">
+        <table mat-table [dataSource]="credentials" style="width: 100%;">
+          <caption></caption>
+          <ng-container matColumnDef="name">
+            <th mat-header-cell *matHeaderCellDef> Credential Id </th>
+            <td mat-cell *matCellDef="let element"> {{element.credentialId}} </td>
+          </ng-container>
+
+          <ng-container matColumnDef="type">
+            <th mat-header-cell *matHeaderCellDef> Public Key </th>
+            <td mat-cell *matCellDef="let element"> {{element.publicKey}} </td>
+          </ng-container>
+
+          <ng-container matColumnDef="identifier">
+            <th mat-header-cell *matHeaderCellDef> AA Identifier </th>
+            <td mat-cell *matCellDef="let element"> {{element.aaguid}} </td>
+          </ng-container>
+
+          <ng-container matColumnDef="actions">
+            <th mat-header-cell *matHeaderCellDef> Actions</th>
+            <td mat-cell *matCellDef="let element">
+              <button mat-menu-item (click)="deleteCredential(element.id)">
+                <mat-icon>delete</mat-icon>
+                <span>Delete</span>
+              </button>
+            </td>
+          </ng-container>
+
+          <tr mat-header-row *matHeaderRowDef="['name', 'type', 'identifier', 'actions']"></tr>
+          <tr mat-row *matRowDef="let row; columns: ['name', 'type', 'identifier', 'actions'];"></tr>
+        </table>
+      </div>
+    </mat-tab>
   </mat-tab-group>
 </div>

--- a/src/app/account/account.component.scss
+++ b/src/app/account/account.component.scss
@@ -6,3 +6,31 @@
 .accordion-margin {
   margin-top: 10px;
 }
+
+.mat-row:hover {
+  background-color: #c6d2f5;
+}
+
+table {
+  width: 100%;
+  table-layout: fixed;
+}
+
+th, td {
+  overflow: hidden;
+  width:auto;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.mat-column-identifier {
+  width: 20% !important;
+}
+
+.mat-column-actions {
+  width: 10% !important;
+}
+
+.mat-header-cell {
+  color: #030746;
+}


### PR DESCRIPTION
closes: gravitee-io/issues#6834
related PR: https://github.com/gravitee-io/gravitee-access-management/pull/1638

A new tab "Passwordless" is added in user "My Account" section.
The 'Register' button allow user to perform in-app self service Webauthn registration.